### PR TITLE
[BUXFIX] liquid-child liquid children (Fixes 18)

### DIFF
--- a/addon/styles/addon.css
+++ b/addon/styles/addon.css
@@ -8,7 +8,7 @@
   position: absolute;
 }
 
-.default-liquid-destination .liquid-child {
+.default-liquid-destination > .liquid-destination-stack > .liquid-child {
   position: absolute;
   top: 0;
   left: 0;
@@ -17,11 +17,11 @@
   visibility: hidden;
 }
 
-.default-liquid-destination .liquid-child > div {
+.default-liquid-destination > .liquid-destination-stack > .liquid-child > div {
   position: absolute;
   top: 0;
   left: 0;
-  
+
   width: 100vw;
   height: 100vh;
   visibility: hidden;

--- a/tests/acceptance/scenarios-test.js
+++ b/tests/acceptance/scenarios-test.js
@@ -60,3 +60,19 @@ test('destination container has correct class if wormholes are present', functio
     assert.ok(find('.default-liquid-destination.has-wormholes').length > 0, 'Has wormholes class');
   });
 });
+
+test('other liquid fire functionality can exist in a wormhole in the default destination', function(assert) {
+  visit('/scenarios/liquid-fire-in-wormhole');
+
+  andThen(() => {
+    assert.ok(find('#content-box'), 'the content box is on screen');
+    assert.equal(find('#showing-other').css('visibility'), 'visible', 'the other is visible');
+    assert.ok(!find('#not-showing-other').length, 'the not other is hidden');
+    click('button:contains(Toggle Inner Content)');
+  });
+
+  andThen(() => {
+    assert.equal(find('#not-showing-other').css('visibility'), 'visible', 'the not other is visible');
+    assert.ok(!find('#showing-other').length, 'the other is hidden');
+  });
+});

--- a/tests/dummy/app/pods/scenarios/liquid-fire-in-wormhole/controller.js
+++ b/tests/dummy/app/pods/scenarios/liquid-fire-in-wormhole/controller.js
@@ -1,0 +1,10 @@
+import Ember from 'ember';
+
+export default Ember.Controller.extend({
+  showingOther: true,
+  actions: {
+    toggleContent() {
+      this.toggleProperty('showingOther');
+    }
+  }
+});

--- a/tests/dummy/app/pods/scenarios/liquid-fire-in-wormhole/template.hbs
+++ b/tests/dummy/app/pods/scenarios/liquid-fire-in-wormhole/template.hbs
@@ -1,0 +1,13 @@
+<button {{action "toggleContent"}}>
+  Toggle Inner Content
+</button>
+
+{{#liquid-wormhole class="blue-box"}}
+  <div id="content-box">
+    {{#liquid-if showingOther}}
+      <span id="showing-other">Show Other</span>
+    {{else}}
+      <span id="not-showing-other">Don't Show Other</span>
+    {{/liquid-if}}
+  </div>
+{{/liquid-wormhole}}

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -19,6 +19,7 @@ Router.map(function() {
     this.route('nested-wormholes');
     this.route('component-in-wormhole');
     this.route('actions-in-wormhole');
+    this.route('liquid-fire-in-wormhole');
   });
 });
 


### PR DESCRIPTION
Fixes #18 

Adds specificity to the addon styles so that non-direct descendant `.liquid-child`ren are not hidden. 