### PR TITLE
Hide nested Liquid Fire elements during transitions

### DIFF
--- a/app/transitions/wormhole.js
+++ b/app/transitions/wormhole.js
@@ -13,6 +13,7 @@ export default function wormhole({ use }) {
       newChild.addClass('liquid-wormhole-temp-element');
 
       oldWormholeElement.css({ visibility: 'hidden' });
+      oldWormholeElement.find('.liquid-child').css({ visibility: 'hidden' });
 
       const offset = oldWormholeElement.offset();
 
@@ -40,6 +41,7 @@ export default function wormhole({ use }) {
       const newChild = newWormholeElement.clone();
 
       newWormholeElement.css({ visibility: 'hidden' });
+      newWormholeElement.find('.liquid-child').css({ visibility: 'hidden' });
 
       const offset = newWormholeElement.offset();
 
@@ -69,10 +71,12 @@ export default function wormhole({ use }) {
     if (this.oldElement && oldWormholeElement) {
       this.oldElement.remove()
       oldWormholeElement.css({ visibility: 'visible' });
+      oldWormholeElement.find('.liquid-child').css({ visibility: 'visible' });
     }
     if (this.newElement && newWormholeElement) {
       this.newElement.remove()
       newWormholeElement.css({ visibility: 'visible' });
+      newWormholeElement.find('.liquid-child').css({ visibility: 'visible' });
     }
   });
 };


### PR DESCRIPTION
This patch fixes a weird behavior (only in Chrome) when using a `liquid-wormhole` that itself has some `liquid-fire` elements — the cloned (and not animating) element will have visible content because `liquid-fire` adds `visibility: visible` style to those elements even though its containing element is marked as `visibility: hidden`. 

I can reproduce via twiddle if this is not totally clear. 