### PR TITLE
Loosen up the version constraint for getowner-polyfill

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
   "dependencies": {
     "ember-cli-babel": "^5.1.7",
     "ember-cli-htmlbars": "^1.1.1",
-    "ember-getowner-polyfill": "1.2.1",
+    "ember-getowner-polyfill": "^1.2.1",
     "ember-weakmap": "2.0.0",
     "perf-primitives": "0.0.4"
   },


### PR DESCRIPTION
in looking at the results of running `ember-dependency-lint` on my app this addon has fallen a version behind many others for `ember-getowner-polyfill` - the other addons all user a less strict version constraint. 

Since this polyfill is an @rwjblue addon I would imagine that semver will be respected and this is a safe choice.