### PR TITLE
Update ember-getowner-polyfill

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
   "dependencies": {
     "ember-cli-babel": "^5.1.7",
     "ember-cli-htmlbars": "^1.1.1",
-    "ember-getowner-polyfill": "^1.2.1",
+    "ember-getowner-polyfill": "^2.0.1",
     "ember-weakmap": "2.0.0",
     "perf-primitives": "0.0.4"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2499,11 +2499,18 @@ ember-fastboot-server@0.5.4:
     simple-dom "^0.3.0"
     source-map-support "^0.4.0"
 
-ember-getowner-polyfill@^1.1.1, ember-getowner-polyfill@^1.2.1:
+ember-getowner-polyfill@^1.1.1:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/ember-getowner-polyfill/-/ember-getowner-polyfill-1.2.3.tgz#ea70f4a48b1c05b91056371d1878bbafe018222e"
   dependencies:
     ember-cli-babel "^5.1.6"
+    ember-cli-version-checker "^1.2.0"
+    ember-factory-for-polyfill "^1.1.0"
+
+ember-getowner-polyfill@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/ember-getowner-polyfill/-/ember-getowner-polyfill-2.0.1.tgz#9bfe2b4d527ed174e76fef2c8f30937d77cb66fb"
+  dependencies:
     ember-cli-version-checker "^1.2.0"
     ember-factory-for-polyfill "^1.1.0"
 


### PR DESCRIPTION
This update remove a deprecated import syntax that is no longer used in
this addon.