### PR TITLE
Update transitions

### DIFF
--- a/addon/transitions/wormhole.js
+++ b/addon/transitions/wormhole.js
@@ -4,64 +4,57 @@ export default function wormhole(context) {
   let oldWormholeElement, newWormholeElement;
 
   if (this.oldElement) {
-    oldWormholeElement = this.oldElement.find('.liquid-wormhole-element:last-child');
+    //get the old wormhole element from inside of the liquid-container
+    oldWormholeElement = this.oldElement.find(
+      ".liquid-wormhole-element:last-child"
+    );
 
     this.oldElement = null;
 
     if (oldWormholeElement.length > 0) {
-      const newChild = oldWormholeElement.clone();
-      newChild.addClass('liquid-wormhole-temp-element');
-
-      oldWormholeElement.css({ visibility: 'hidden' });
-      oldWormholeElement.find('.liquid-child').css({ visibility: 'hidden' });
-
       const offset = oldWormholeElement.offset();
 
-      newChild.css({
-        position: 'absolute',
+      oldWormholeElement.css({
+        position: "absolute",
         top: offset.top,
         left: offset.left,
-        bottom: '',
-        right: '',
-        margin: '0px',
-        transform: ''
+        bottom: "",
+        right: "",
+        margin: "0px",
+        transform: ""
       });
 
-      newChild.appendTo(oldWormholeElement.parent());
-      this.oldElement = newChild;
+      this.oldElement = oldWormholeElement;
     }
   }
 
   if (this.newElement) {
-    newWormholeElement = this.newElement.find('.liquid-wormhole-element:last-child');
+    //get the new wormhole element from inside of the liquid-container
+    newWormholeElement = this.newElement.find(
+      ".liquid-wormhole-element:last-child"
+    );
 
     this.newElement = null;
 
     if (newWormholeElement.length > 0) {
-      const newChild = newWormholeElement.clone();
-
-      newWormholeElement.css({ visibility: 'hidden' });
-      newWormholeElement.find('.liquid-child').css({ visibility: 'hidden' });
-
       const offset = newWormholeElement.offset();
 
-      newChild.css({
-        position: 'absolute',
+      newWormholeElement.css({
+        position: "absolute",
         top: offset.top,
         left: offset.left,
-        bottom: '',
-        right: '',
-        margin: '0px',
-        transform: ''
+        bottom: "",
+        right: "",
+        margin: "0px",
+        transform: ""
       });
 
-      newChild.appendTo(newWormholeElement.parent());
-      this.newElement = newChild;
+      this.newElement = newWormholeElement;
     }
   }
 
   var animation;
-  if (typeof use.handler === 'function') {
+  if (typeof use.handler === "function") {
     animation = use.handler;
   } else {
     animation = context.lookup(use.name);
@@ -69,14 +62,12 @@ export default function wormhole(context) {
 
   return animation.apply(this, use.args).finally(() => {
     if (this.oldElement && oldWormholeElement) {
-      this.oldElement.remove();
-      oldWormholeElement.css({ visibility: 'visible' });
-      oldWormholeElement.find('.liquid-child').css({ visibility: 'visible' });
+      oldWormholeElement.css({ visibility: "visible" });
+      oldWormholeElement.find(".liquid-child").css({ visibility: "visible" });
     }
     if (this.newElement && newWormholeElement) {
-      this.newElement.remove();
-      newWormholeElement.css({ visibility: 'visible' });
-      newWormholeElement.find('.liquid-child').css({ visibility: 'visible' });
+      newWormholeElement.css({ visibility: "visible" });
+      newWormholeElement.find(".liquid-child").css({ visibility: "visible" });
     }
   });
 }

--- a/addon/transitions/wormhole.js
+++ b/addon/transitions/wormhole.js
@@ -4,7 +4,7 @@ export default function wormhole(context) {
   let oldWormholeElement, newWormholeElement;
 
   if (this.oldElement) {
-    //get the old wormhole element from inside of the liquid-container
+    //this.oldElement is the liquid-container, get the wormhole element inside.
     oldWormholeElement = this.oldElement.find(
       ".liquid-wormhole-element:last-child"
     );
@@ -29,7 +29,7 @@ export default function wormhole(context) {
   }
 
   if (this.newElement) {
-    //get the new wormhole element from inside of the liquid-container
+    //this.newElement is the liquid-container, get the wormhole element inside.
     newWormholeElement = this.newElement.find(
       ".liquid-wormhole-element:last-child"
     );
@@ -60,14 +60,5 @@ export default function wormhole(context) {
     animation = context.lookup(use.name);
   }
 
-  return animation.apply(this, use.args).finally(() => {
-    if (this.oldElement && oldWormholeElement) {
-      oldWormholeElement.css({ visibility: "visible" });
-      oldWormholeElement.find(".liquid-child").css({ visibility: "visible" });
-    }
-    if (this.newElement && newWormholeElement) {
-      newWormholeElement.css({ visibility: "visible" });
-      newWormholeElement.find(".liquid-child").css({ visibility: "visible" });
-    }
-  });
+  return animation.apply(this, use.args);
 }

--- a/tests/acceptance/scenarios-test.js
+++ b/tests/acceptance/scenarios-test.js
@@ -1,8 +1,8 @@
-import wait from 'ember-test-helpers/wait';
-import { click, findAll, visit } from 'ember-native-dom-helpers';
-import { startApp, destroyApp } from '../helpers/app-lifecycle';
+import wait from "ember-test-helpers/wait";
+import { click, findAll, visit } from "ember-native-dom-helpers";
+import { startApp, destroyApp } from "../helpers/app-lifecycle";
 
-import { module, test } from 'qunit';
+import { module, test } from "qunit";
 
 function visibility(selector) {
   return window.getComputedStyle(find(selector)[0]).visibility;
@@ -10,7 +10,7 @@ function visibility(selector) {
 
 let app;
 
-module('Acceptance: Scenarios', function(hooks) {
+module("Acceptance: Scenarios", function(hooks) {
   hooks.beforeEach(function() {
     app = startApp();
   });
@@ -19,72 +19,107 @@ module('Acceptance: Scenarios', function(hooks) {
     destroyApp(app);
   });
 
-  test('components are not destroyed until animation has finished', async function(assert) {
-    await visit('/scenarios/component-in-wormhole');
+  test("components are not destroyed until animation has finished", async function(assert) {
+    await visit("/scenarios/component-in-wormhole");
 
-    click('[data-test-toggle-wormhole]');
-    assert.equal(find('.liquid-wormhole-element').text().trim(), 'testing123', 'component markup still exists');
+    click("[data-test-toggle-wormhole]");
+    assert.equal(
+      find(".liquid-wormhole-element")
+        .text()
+        .trim(),
+      "testing123",
+      "component markup still exists"
+    );
   });
 
-  test('components are visible during the transition', async function(assert) {
-    visit('/scenarios/component-in-wormhole');
+  test("components are visible during the transition", async function(assert) {
+    visit("/scenarios/component-in-wormhole");
     setTimeout(() => {
-      assert.equal(visibility('.liquid-wormhole-element:first'), 'hidden');
-      assert.equal(visibility('.liquid-wormhole-element:last'), 'visible');
+      assert.equal(visibility(".liquid-wormhole-element:last"), "visible");
     }, 100);
 
     await wait();
-    click('[data-test-toggle-wormhole]');
+    click("[data-test-toggle-wormhole]");
     setTimeout(() => {
-      assert.equal(visibility('.liquid-wormhole-element:first'), 'hidden');
-      assert.equal(visibility('.liquid-wormhole-element:last'), 'visible');
+      assert.equal(visibility(".liquid-wormhole-element:last"), "visible");
     }, 100);
 
     await wait();
   });
 
-  test('templates still have action context once rendered', async function(assert) {
-    await visit('/scenarios/actions-in-wormhole');
+  test("templates still have action context once rendered", async function(assert) {
+    await visit("/scenarios/actions-in-wormhole");
 
-    assert.equal(find('.default-liquid-destination .liquid-wormhole-element').length, 1, 'it has a wormhole');
+    assert.equal(
+      find(".default-liquid-destination .liquid-wormhole-element").length,
+      1,
+      "it has a wormhole"
+    );
 
-    await click('[data-test-toggle-wormhole]');
+    await click("[data-test-toggle-wormhole]");
 
-    assert.equal(find('.default-liquid-destination .liquid-wormhole-element').length, 0, 'it closed the wormhole');
+    assert.equal(
+      find(".default-liquid-destination .liquid-wormhole-element").length,
+      0,
+      "it closed the wormhole"
+    );
   });
 
-  test('nested wormholes work properly', async function(assert) {
-    await visit('/scenarios/nested-wormholes');
+  test("nested wormholes work properly", async function(assert) {
+    await visit("/scenarios/nested-wormholes");
 
-    const wormholes = findAll('.liquid-wormhole-element');
+    const wormholes = findAll(".liquid-wormhole-element");
 
     const firstWormhole = wormholes[0];
     const secondWormhole = wormholes[1];
     const thirdWormhole = wormholes[2];
 
-    assert.ok(firstWormhole.classList.contains('green-box'), 'First wormhole renders in correct order');
-    assert.ok(secondWormhole.classList.contains('blue-box'), 'Second wormhole renders in correct order');
-    assert.ok(thirdWormhole.classList.contains('red-box'), 'Third wormhole renders in correct order');
+    assert.ok(
+      firstWormhole.classList.contains("green-box"),
+      "First wormhole renders in correct order"
+    );
+    assert.ok(
+      secondWormhole.classList.contains("blue-box"),
+      "Second wormhole renders in correct order"
+    );
+    assert.ok(
+      thirdWormhole.classList.contains("red-box"),
+      "Third wormhole renders in correct order"
+    );
   });
 
-  test('destination container has correct class if wormholes are present', async function(assert) {
-    assert.ok(find('.default-liquid-destination.has-wormholes').length === 0, 'No wormholes class');
+  test("destination container has correct class if wormholes are present", async function(assert) {
+    assert.ok(
+      find(".default-liquid-destination.has-wormholes").length === 0,
+      "No wormholes class"
+    );
 
-    await visit('/scenarios/nested-wormholes');
+    await visit("/scenarios/nested-wormholes");
 
-    assert.ok(find('.default-liquid-destination.has-wormholes').length > 0, 'Has wormholes class');
+    assert.ok(
+      find(".default-liquid-destination.has-wormholes").length > 0,
+      "Has wormholes class"
+    );
   });
 
-  test('other liquid fire functionality can exist in a wormhole in the default destination', async function(assert) {
-    await visit('/scenarios/liquid-fire-in-wormhole');
+  test("other liquid fire functionality can exist in a wormhole in the default destination", async function(assert) {
+    await visit("/scenarios/liquid-fire-in-wormhole");
 
-    assert.ok(find('#content-box'), 'the content box is on screen');
-    assert.equal(find('#showing-other').css('visibility'), 'visible', 'the other is visible');
-    assert.ok(!find('#not-showing-other').length, 'the not other is hidden');
+    assert.ok(find("#content-box"), "the content box is on screen");
+    assert.equal(
+      find("#showing-other").css("visibility"),
+      "visible",
+      "the other is visible"
+    );
+    assert.ok(!find("#not-showing-other").length, "the not other is hidden");
 
-    await click('[data-test-toggle-inner]');
+    await click("[data-test-toggle-inner]");
 
-    assert.equal(find('#not-showing-other').css('visibility'), 'visible', 'the not other is visible');
-    assert.ok(!find('#showing-other').length, 'the other is hidden');
+    assert.equal(
+      find("#not-showing-other").css("visibility"),
+      "visible",
+      "the not other is visible"
+    );
+    assert.ok(!find("#showing-other").length, "the other is hidden");
   });
 });


### PR DESCRIPTION
Transitions are cleaned up to remove now redundant duplication of DOM elements.

One test updated as there are no longer two elements in the DOM. 

All tests pass.

All the transitions in the dummy app work just fine.... Except ....!! One unrelated error to note, after forking and doing a local install BEFORE making any changes, the sending components demo `http://localhost:4200/#/docs/components` was throwing an error. So I wasn't able to visually test that !!

And some changes in the commits are due to vscode/prettier formatting the code.

```
runtime.js:6407 Uncaught TypeError: Cannot read property 'commit' of null
    at Environment.commit (runtime.js:6407)
    at Environment.commit (environment.js:266)
    at InteractiveRenderer._renderRootsTransaction (renderer.js:359)
    at InteractiveRenderer._revalidate (renderer.js:393)
    at invoke (backburner.js:205)
    at Queue.flush (backburner.js:125)
    at DeferredActionQueues.flush (backburner.js:278)
    at Backburner.end (backburner.js:410)
    at Backburner._run (backburner.js:760)
    at Backburner._join (backburner.js:736)
commit @ runtime.js:6407
commit @ environment.js:266
_renderRootsTransaction @ renderer.js:359
_revalidate @ renderer.js:393
invoke @ backburner.js:205
flush @ backburner.js:125
flush @ backburner.js:278
end @ backburner.js:410
_run @ backburner.js:760
_join @ backburner.js:736
join @ backburner.js:477
run.join @ ember-metal.js:4366
handler @ action.js:102
(anonymous) @ event_dispatcher.js:234
dispatch @ jquery.js:5183
elemData.handle @ jquery.js:4991
liquid-destination.js:63 Uncaught TypeError: Cannot read property 'find' of undefined
    at Class.removeWormhole (liquid-destination.js:63)
    at Class.removeWormhole (liquid-wormhole.js:35)
    at Class.willDestroyElement (liquid-wormhole.js:53)
    at Class.superWrapper [as willDestroyElement] (ember-utils.js:420)
    at Class.trigger (core_view.js:62)
    at Class.superWrapper [as trigger] (ember-utils.js:420)
    at ComponentStateBucket.destroy (curly-component-state-bucket.js:34)
    at SimpleBlockTracker.destroy (runtime.js:2171)
    at UpdatableBlockTracker.destroy (runtime.js:2171)
    at SimpleBlockTracker.destroy (runtime.js:2171)
```