### PR TITLE
ci: drop support for node 4.x and node 6.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: node_js
 node_js:
   # we recommend testing addons with the same minimum supported node version as Ember CLI
   # so that your addon works for all apps
-  - "4"
+  - "8"
 
 sudo: false
 dist: trusty

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "repository": "https://github.com/pzuraq/liquid-wormhole",
   "engines": {
-    "node": "^4.5 || 6.* || >= 7.*"
+    "node": "8.* || >= 10.*"
   },
   "author": "Christopher Garrett <cmg@pzuraq.co>",
   "license": "MIT",


### PR DESCRIPTION
Related to: https://github.com/pzuraq/liquid-wormhole/pull/61#issuecomment-457851544

@pzuraq Having all kinds of issues on CI with the combination of Yarn + Node 4.x || 6.x. Going directly to Node 8.x min version support just works.

Initially attempted to `ember-cli-update` my way to latest this morning but for this addon it's non-trivial, meaning I can't just do it in an hour.

Are you willing to drop support for Node 4.x && 6.x on a new major semver release?

Next steps would be to `ember-cli-update` our way to latest.

---

related yarn/babel issues:

https://github.com/yarnpkg/yarn/issues/6914
https://github.com/babel/babel/issues/8269
