### PR TITLE
fix: avoid updating `nodes` twice in same render (fix #70)

### DIFF
--- a/addon/components/liquid-destination.js
+++ b/addon/components/liquid-destination.js
@@ -65,11 +65,13 @@ export default Component.extend({
     const stack = this.stackMap.get(stackName);
     const item = stack.find(item => item && item.wormhole === wormhole);
 
-    const newNodes = item.get('nodes').clone();
-    item.set('nodes', newNodes);
-    item.set('_replaceNodes', true);
+    next(() => {
+      const newNodes = item.get('nodes').clone();
+      item.set('nodes', newNodes);
+      item.set('_replaceNodes', true);
 
-    next(() => stack.removeObject(item));
+      next(() => stack.removeObject(item));
+    });
   },
 
   flushWormholeQueue() {


### PR DESCRIPTION
Looks like `removeWormhole` can get called in the same cycle as
`didInsertELement`, and both touch `item.nodes`, which triggers
an error in Ember 3.22 that looks something like this:

```
Uncaught Error: Assertion Failed: You attempted to update `nodes` on `<EmberObject:ember169>`, but it had already been used previously in the same computation.  Attempting to update a value after using it in a computation can cause logical errors, infinite revalidation bugs, and performance issues, and is not supported.

`nodes` was first used:
....
```

To work around this for now (probably not the best way) we postpone the
update to the next turn of the rendering loop.
**Note: I am not sure if this change may have other (negative) side-effects -- just saw that it made the other error go away....**